### PR TITLE
Make sample code self-contained & fix errors inside

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,18 @@ Usage
 -----
 
 ```go
+package main
+
 import (
+	"context"
+	"fmt"
 	"github.com/apache/airflow-client-go/airflow"
 )
 
 func main() {
 	cli := airflow.NewAPIClient(&airflow.Configuration{
 		Scheme:   "http",
-		Host:     "localhost:28080",
+		Host:     "localhost:8080",
 		BasePath: "/api/v1",
 	})
 
@@ -44,11 +48,11 @@ func main() {
 	}
 	ctx := context.WithValue(context.Background(), airflow.ContextBasicAuth, cred)
 
-	variable, _, err := client.VariableApi.GetVariable(ctx, "foo")
+	variable, _, err := cli.VariableApi.GetVariable(ctx, "foo")
 	if err != nil {
-		fmt.Println(variable)
-	} else {
 		fmt.Println(err)
+	} else {
+		fmt.Println(variable)
 	}
 }
 ```


### PR DESCRIPTION
- make the sample usage code self-contained
- fix a few errors inside:
  - wrong variable name ("cli")
  - `if-else` block handling err was wrong (it tried to print result when `err` is not `nil`).