### PR TITLE
protect main branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,4 +37,9 @@ github:
   enabled_merge_buttons:
     squash: true
     merge: false
-    rebase: false
+    rebase: true
+
+  protected_branches:
+    main:
+      required_pull_request_reviews:
+        required_approving_review_count: 1


### PR DESCRIPTION
Switch to main as the default branch before doing an official release.

INFRA ticket filed at https://issues.apache.org/jira/browse/INFRA-22161.