### PR TITLE
Update the signing command

### DIFF
--- a/dev/sign.sh
+++ b/dev/sign.sh
@@ -28,6 +28,6 @@ SIGN_WITH="${SIGN_WITH:-apache.org}"
 
 for name in "${@}"
 do
-    gpg --yes -armor --local-user "$SIGN_WITH" --output "${name}.asc" --detach-sig "${name}"
+    gpg --yes --armor --local-user "$SIGN_WITH" --output "${name}.asc" --detach-sig "${name}"
     shasum -a 512 "${name}" > "${name}.sha512"
 done


### PR DESCRIPTION
-amor was used instead of --amor.

Also added the executable bit to dev/sign.sh

Thanks, @potiuk for the `-amor/--amor` explanation!